### PR TITLE
fix npm script rebuild dir

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -14,7 +14,7 @@
     "build": "roadhog build && webpack --config ./webpack.config.main.babel.js",
     "lint": "eslint --ext .js src test webpack.config.babel.js",
     "test": "mocha test/**/*-test.js --require babel-register --require ./test/setup --no-timeouts",
-    "rebuild": "electron-rebuild -m ./app/node_modules",
+    "rebuild": "electron-rebuild -m ./app",
     "pack": "npm run build && npm run rebuild && build",
     "pack:dir": "npm run build && npm run rebuild && build --dir",
     "pack:justBuild": "build --dir",


### PR DESCRIPTION
`npm run pack` 执行报错，排查发现是rebuild的目录不对